### PR TITLE
Allow custom Chrome path

### DIFF
--- a/Backend/README.md
+++ b/Backend/README.md
@@ -26,8 +26,12 @@ Este backend está construido con Node.js y Express. Provee endpoints para:
 ```
 # Puerto opcional para el servidor
 PORT=3001
+# Ruta al ejecutable de Chrome
+# (por defecto se usa C:/Program Files/Google/Chrome/Application/chrome.exe)
+CHROME_PATH=C:/Program Files/Google/Chrome/Application/chrome.exe
 ```
 
 ## Notas
 - Personaliza los endpoints según tus necesidades.
 - Este backend es solo un punto de partida.
+- Si el cliente de WhatsApp no inicia, revisa la ruta definida en `CHROME_PATH`.

--- a/Backend/index.js
+++ b/Backend/index.js
@@ -8,13 +8,17 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
+// Leer ruta de Chrome desde variable de entorno con valor por defecto
+const chromePath = process.env.CHROME_PATH ||
+  'C:/Program Files/Google/Chrome/Application/chrome.exe';
+
 // Inicializar cliente WhatsApp
 const client = new Client({
     authStrategy: new LocalAuth(),
     puppeteer: {
         headless: true,
         args: ['--no-sandbox'],
-        executablePath: 'C:/Program Files/Google/Chrome/Application/chrome.exe' // Cambia la ruta si tu Chrome está en otro lugar
+        executablePath: chromePath // cambia mediante CHROME_PATH si es necesario
     }
 });
 


### PR DESCRIPTION
## Summary
- make Chrome executable path configurable with `CHROME_PATH`
- document the new variable in the backend README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866b32260ac832084dc87ad685b8d03