### PR TITLE
Add simple pipeline and chat

### DIFF
--- a/Backend/data.json
+++ b/Backend/data.json
@@ -1,0 +1,14 @@
+{
+  "stages": [
+    {"id": 1, "name": "Incoming leads", "position": 1},
+    {"id": 2, "name": "First Contact", "position": 2}
+  ],
+  "contacts": [
+    {"id": 1, "name": "Juan Pérez", "project": "Proyecto X", "amount": 5000, "stageId": 1},
+    {"id": 2, "name": "María López", "project": "Proyecto Y", "amount": 3000, "stageId": 2}
+  ],
+  "messages": [
+    {"id": 1, "contactId": 1, "direction": "in", "content": "Hola", "timestamp": "2024-01-01T12:00:00Z"},
+    {"id": 2, "contactId": 1, "direction": "out", "content": "¿Cómo estás?", "timestamp": "2024-01-01T12:05:00Z"}
+  ]
+}

--- a/Backend/db.js
+++ b/Backend/db.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+const DATA_PATH = path.join(__dirname, 'data.json');
+
+function loadData() {
+  if (!fs.existsSync(DATA_PATH)) {
+    return { stages: [], contacts: [], messages: [] };
+  }
+  const raw = fs.readFileSync(DATA_PATH, 'utf-8');
+  return JSON.parse(raw);
+}
+
+function saveData(data) {
+  fs.writeFileSync(DATA_PATH, JSON.stringify(data, null, 2));
+}
+
+function getData() {
+  if (!global.__DATA__) {
+    global.__DATA__ = loadData();
+  }
+  return global.__DATA__;
+}
+
+module.exports = { getData, saveData };

--- a/Backend/index.js
+++ b/Backend/index.js
@@ -11,6 +11,7 @@ if (process.env.NODE_ENV !== 'test') {
 const app = express();
 app.use(cors());
 app.use(express.json());
+const { getData, saveData } = require('./db');
 
 // Leer ruta de Chrome desde variable de entorno con valor por defecto
 const chromePath = process.env.CHROME_PATH ||
@@ -115,6 +116,103 @@ app.get('/api/wa-contacts', async (req, res) => {
   } catch (err) {
     res.status(500).json({ error: 'No se pudieron obtener los contactos de WhatsApp.' });
   }
+});
+
+// ---------- Pipeline CRUD Endpoints ----------
+app.get('/api/stages', (req, res) => {
+  const data = getData();
+  res.json(data.stages.sort((a, b) => a.position - b.position));
+});
+
+app.post('/api/stages', (req, res) => {
+  const { name } = req.body;
+  if (!name) return res.status(400).json({ error: 'name required' });
+  const data = getData();
+  const id = Date.now();
+  const position = data.stages.length + 1;
+  data.stages.push({ id, name, position });
+  saveData(data);
+  res.json({ id, name, position });
+});
+
+app.put('/api/stages/:id', (req, res) => {
+  const { id } = req.params;
+  const { name, position } = req.body;
+  const data = getData();
+  const stage = data.stages.find(s => s.id == id);
+  if (!stage) return res.status(404).json({ error: 'not found' });
+  if (name !== undefined) stage.name = name;
+  if (position !== undefined) stage.position = position;
+  saveData(data);
+  res.json(stage);
+});
+
+app.delete('/api/stages/:id', (req, res) => {
+  const { id } = req.params;
+  const data = getData();
+  const idx = data.stages.findIndex(s => s.id == id);
+  if (idx === -1) return res.status(404).json({ error: 'not found' });
+  data.stages.splice(idx, 1);
+  saveData(data);
+  res.json({ success: true });
+});
+
+// Contacts CRUD (for pipeline)
+app.get('/api/pipeline-contacts', (req, res) => {
+  const data = getData();
+  res.json(data.contacts);
+});
+
+app.post('/api/pipeline-contacts', (req, res) => {
+  const { name, project, amount, stageId } = req.body;
+  const data = getData();
+  const id = Date.now();
+  data.contacts.push({ id, name, project, amount, stageId });
+  saveData(data);
+  res.json({ id, name, project, amount, stageId });
+});
+
+app.put('/api/pipeline-contacts/:id', (req, res) => {
+  const { id } = req.params;
+  const data = getData();
+  const contact = data.contacts.find(c => c.id == id);
+  if (!contact) return res.status(404).json({ error: 'not found' });
+  const { name, project, amount, stageId } = req.body;
+  if (name !== undefined) contact.name = name;
+  if (project !== undefined) contact.project = project;
+  if (amount !== undefined) contact.amount = amount;
+  if (stageId !== undefined) contact.stageId = stageId;
+  saveData(data);
+  res.json(contact);
+});
+
+app.delete('/api/pipeline-contacts/:id', (req, res) => {
+  const { id } = req.params;
+  const data = getData();
+  const idx = data.contacts.findIndex(c => c.id == id);
+  if (idx === -1) return res.status(404).json({ error: 'not found' });
+  data.contacts.splice(idx, 1);
+  saveData(data);
+  res.json({ success: true });
+});
+
+// Messages
+app.get('/api/messages/:contactId', (req, res) => {
+  const { contactId } = req.params;
+  const data = getData();
+  const msgs = data.messages.filter(m => m.contactId == contactId);
+  res.json(msgs);
+});
+
+app.post('/api/messages', (req, res) => {
+  const { contactId, content, direction = 'out' } = req.body;
+  const data = getData();
+  const id = Date.now();
+  const timestamp = new Date().toISOString();
+  const message = { id, contactId, content, direction, timestamp };
+  data.messages.push(message);
+  saveData(data);
+  res.json(message);
 });
 
 const PORT = process.env.PORT || 3001;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "lucide-react": "^0.515.0",
         "react": "^18.2.0",
+        "react-beautiful-dnd": "^13.1.1",
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
@@ -1899,7 +1900,6 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3525,6 +3525,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
+      "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -3572,6 +3582,27 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.34",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.34.tgz",
+      "integrity": "sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -4613,6 +4644,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -4646,6 +4686,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -5222,6 +5268,21 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -6756,6 +6817,12 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -6952,7 +7019,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7393,6 +7459,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -7441,6 +7524,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -7451,6 +7540,26 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-beautiful-dnd": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz",
+      "integrity": "sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==",
+      "deprecated": "react-beautiful-dnd is now deprecated. Context and options: https://github.com/atlassian/react-beautiful-dnd/issues/2672",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2",
+        "css-box-model": "^1.2.0",
+        "memoize-one": "^5.1.1",
+        "raf-schd": "^4.0.2",
+        "react-redux": "^7.2.0",
+        "redux": "^4.0.4",
+        "use-memo-one": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.5 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-dom": {
@@ -7470,9 +7579,32 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "7.2.9",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
+      "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -7519,6 +7651,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/regenerate": {
@@ -8269,6 +8410,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tldts": {
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
@@ -8488,6 +8635,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-memo-one": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "lucide-react": "^0.515.0",
     "react": "^18.2.0",
+    "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {

--- a/frontend/src/PipelineApp.jsx
+++ b/frontend/src/PipelineApp.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { PipelineBoard } from './pipeline';
+import './index.css';
+
+export default function PipelineApp() {
+  return (
+    <div className="h-screen flex flex-col">
+      <header className="p-4 shadow font-bold">CRM Pipeline</header>
+      <div className="flex-1 overflow-hidden">
+        <PipelineBoard />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
-import App from "./App.jsx";
+import PipelineApp from "./PipelineApp.jsx";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
+    <PipelineApp />
   </React.StrictMode>
 );

--- a/frontend/src/pipeline/ChatPanel.jsx
+++ b/frontend/src/pipeline/ChatPanel.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+
+export default function ChatPanel({ contact, messages, onSend }) {
+  const [text, setText] = useState('');
+
+  if (!contact) {
+    return <div className="w-80 border-l p-4 text-gray-500">Seleccione un contacto</div>;
+  }
+
+  return (
+    <div className="w-80 border-l flex flex-col">
+      <div className="p-4 border-b font-semibold">{contact.name}</div>
+      <div className="flex-1 overflow-auto p-4 space-y-2">
+        {messages.map(m => (
+          <div key={m.id} className={`text-sm ${m.direction === 'out' ? 'text-right' : ''}`}>{m.content}</div>
+        ))}
+      </div>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (!text) return;
+          onSend(text);
+          setText('');
+        }}
+        className="p-2 border-t flex"
+      >
+        <input
+          className="flex-1 border rounded px-2 text-sm"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Escribe un mensaje"
+        />
+        <button type="submit" className="ml-2 px-3 rounded bg-blue-600 text-white text-sm">Enviar</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pipeline/PipelineBoard.jsx
+++ b/frontend/src/pipeline/PipelineBoard.jsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from 'react';
+import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+import { pipelineService } from '../services/api';
+import ChatPanel from './ChatPanel';
+
+export default function PipelineBoard() {
+  const [stages, setStages] = useState([]);
+  const [contacts, setContacts] = useState([]);
+  const [active, setActive] = useState(null);
+  const [messages, setMessages] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      const [s, c] = await Promise.all([
+        pipelineService.getStages(),
+        pipelineService.getContacts(),
+      ]);
+      setStages(s);
+      setContacts(c);
+    }
+    load();
+  }, []);
+
+  async function loadMessages(id) {
+    const msgs = await pipelineService.getMessages(id);
+    setMessages(msgs);
+  }
+
+  const contactsByStage = {};
+  stages.forEach(s => {
+    contactsByStage[s.id] = contacts.filter(c => c.stageId === s.id);
+  });
+
+  const onDragEnd = async (result) => {
+    const { draggableId, destination } = result;
+    if (!destination) return;
+    const contactId = parseInt(draggableId, 10);
+    const stageId = parseInt(destination.droppableId, 10);
+    await pipelineService.updateContact(contactId, { stageId });
+    const updated = await pipelineService.getContacts();
+    setContacts(updated);
+  };
+
+  const handleSelect = async (contact) => {
+    setActive(contact);
+    const msgs = await pipelineService.getMessages(contact.id);
+    setMessages(msgs);
+  };
+
+  return (
+    <div className="flex">
+      <div className="flex-1 overflow-auto flex" style={{ gap: '1rem' }}>
+        <DragDropContext onDragEnd={onDragEnd}>
+          {stages.map(stage => (
+            <Droppable droppableId={String(stage.id)} key={stage.id}>
+              {(provided) => (
+                <div
+                  ref={provided.innerRef}
+                  {...provided.droppableProps}
+                  className="bg-gray-50 rounded p-2 w-64 flex-shrink-0"
+                >
+                  <h3 className="font-semibold mb-2">{stage.name}</h3>
+                  {contactsByStage[stage.id].map((c, index) => (
+                    <Draggable draggableId={String(c.id)} index={index} key={c.id}>
+                      {(prov) => (
+                        <div
+                          ref={prov.innerRef}
+                          {...prov.draggableProps}
+                          {...prov.dragHandleProps}
+                          className="bg-white rounded shadow p-2 mb-2 cursor-pointer"
+                          onClick={() => handleSelect(c)}
+                        >
+                          <div className="font-medium">{c.name}</div>
+                          <div className="text-sm text-gray-500">{c.project}</div>
+                          <div className="text-sm text-gray-500">${'{'}c.amount{'}'}</div>
+                        </div>
+                      )}
+                    </Draggable>
+                  ))}
+                  {provided.placeholder}
+                </div>
+              )}
+            </Droppable>
+          ))}
+        </DragDropContext>
+      </div>
+      <ChatPanel contact={active} messages={messages} onSend={async (text) => {
+        if (!active) return;
+        const msg = await pipelineService.sendMessage(active.id, text);
+        setMessages(prev => [...prev, msg]);
+      }} />
+    </div>
+  );
+}

--- a/frontend/src/pipeline/index.js
+++ b/frontend/src/pipeline/index.js
@@ -1,0 +1,2 @@
+export { default as PipelineBoard } from './PipelineBoard.jsx';
+export { default as ChatPanel } from './ChatPanel.jsx';

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -52,6 +52,59 @@ const messagesService = {
   },
 };
 
+// Pipeline services
+const pipelineService = {
+  getStages: async () => {
+    const res = await fetch('http://localhost:3001/api/stages');
+    if (!res.ok) throw new Error('Error cargando etapas');
+    return await res.json();
+  },
+  createStage: async (name) => {
+    const res = await fetch('http://localhost:3001/api/stages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    return await res.json();
+  },
+  updateStage: async (id, payload) => {
+    const res = await fetch(`http://localhost:3001/api/stages/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    return await res.json();
+  },
+  deleteStage: async (id) => {
+    const res = await fetch(`http://localhost:3001/api/stages/${id}`, { method: 'DELETE' });
+    return await res.json();
+  },
+  getContacts: async () => {
+    const res = await fetch('http://localhost:3001/api/pipeline-contacts');
+    return await res.json();
+  },
+  updateContact: async (id, payload) => {
+    const res = await fetch(`http://localhost:3001/api/pipeline-contacts/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    return await res.json();
+  },
+  getMessages: async (contactId) => {
+    const res = await fetch(`http://localhost:3001/api/messages/${contactId}`);
+    return await res.json();
+  },
+  sendMessage: async (contactId, content) => {
+    const res = await fetch('http://localhost:3001/api/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contactId, content }),
+    });
+    return await res.json();
+  },
+};
+
 // Servicio de estadísticas simulado
 const statsService = {
   getDashboardStats: async () => {
@@ -144,6 +197,6 @@ export async function sendWhatsAppMessage({ to, message }) {
   return data;
 }
 
-export { authService, contactsService, messagesService, statsService, configService };
+export { authService, contactsService, messagesService, statsService, configService, pipelineService };
 
 


### PR DESCRIPTION
## Summary
- store demo stages, contacts and messages in `Backend/data.json`
- add helper for reading/writing this demo DB
- expose CRUD endpoints for stages, contacts and messages
- add React pipeline board with drag/drop and basic chat
- render the new `PipelineApp`
- add `react-beautiful-dnd` dependency

## Testing
- `cd Backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867eb1410148320bb458598549458b3